### PR TITLE
Fix CLI breaking on nodes wihtout deps

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -37,9 +37,9 @@ process.stdin.pipe(concat(function(body) {
     label.push(')')
     label = label.join('')
 
-    var nodes = node.deps.map(function(node) {
+    var nodes = node.deps ? node.deps.map(function(node) {
       return prepareForArchyInput(node)
-    })
+    }) : []
 
     return { label: label, nodes: nodes }
   }


### PR DESCRIPTION
```
browserify-breakdown < _dist/js/index.min.js
/home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:40
    var nodes = node.deps.map(function(node) {
                         ^

TypeError: Cannot read property 'map' of undefined
    at prepareForArchyInput (/home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:40:26)
    at /home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:41:14
    at Array.map (native)
    at prepareForArchyInput (/home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:40:27)
    at /home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:41:14
    at Array.map (native)
    at prepareForArchyInput (/home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:40:27)
    at /home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:41:14
    at Array.map (native)
    at prepareForArchyInput (/home/sam/n/lib/node_modules/browserify-breakdown/bin/cmd.js:40:27)

```